### PR TITLE
Slightly more complicated solution than hoped for, but all working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "archytas"
-version = "1.0.3"
+version = "1.0.4"
 description = "A library for pairing LLM agents with tools so they perform open ended tasks"
 authors = ["David Andrew Samson <david.andrew.engineer@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Because of the way that the decorated functions are globals, we need to keep a reference to the original, un-modified function.