### PR TITLE
Disable tool method

### DIFF
--- a/archytas/prompt.py
+++ b/archytas/prompt.py
@@ -57,7 +57,7 @@ def notes(*, ask_user: bool) -> str:
 """.strip()
 
 
-def build_prompt(tools: list[Callable] | dict[str, Callable]) -> str:
+def build_prompt(tools: list[Callable]) -> str:
     """
     Build the prompt for the ReAct agent
 
@@ -67,8 +67,6 @@ def build_prompt(tools: list[Callable] | dict[str, Callable]) -> str:
     Returns:
         str: The prompt for the ReAct agent
     """
-    if isinstance(tools, dict):
-        tools = list(tools.values())
     # collect all the tool names (including class.method names)
     tool_names = build_all_tool_names(tools)
 

--- a/archytas/prompt.py
+++ b/archytas/prompt.py
@@ -57,7 +57,7 @@ def notes(*, ask_user: bool) -> str:
 """.strip()
 
 
-def build_prompt(tools: list[Callable]) -> str:
+def build_prompt(tools: list[Callable] | dict[str, Callable]) -> str:
     """
     Build the prompt for the ReAct agent
 
@@ -67,6 +67,8 @@ def build_prompt(tools: list[Callable]) -> str:
     Returns:
         str: The prompt for the ReAct agent
     """
+    if isinstance(tools, dict):
+        tools = list(tools.values())
     # collect all the tool names (including class.method names)
     tool_names = build_all_tool_names(tools)
 

--- a/archytas/react.py
+++ b/archytas/react.py
@@ -4,6 +4,7 @@ from archytas.tools import ask_user
 from archytas.tool_utils import make_tool_dict
 import asyncio
 import json
+import re
 import pdb
 import sys
 import logging
@@ -120,8 +121,17 @@ class ReActAgent(Agent):
 
     def disable(self, *tool_names):
         for tool_name in tool_names:
+            if "." not in tool_name:
+                pattern = re.compile(f"\S+\.{tool_name}$")
+                matches = list(filter(lambda name: pattern.match(name), self.tools.keys()))
+                if len(matches) > 1:
+                    raise ValueError(f"Ambiguous name: Multiple tools called '{tool_name}'")
+                elif len(matches) == 1:
+                    tool_name = matches[0].string
             if tool_name in self.tools:
                 self.tools.pop(tool_name)
+            else:
+                raise AttributeError(f"Cannot disable nonexistent tool: {tool_name}")
         self.prompt = build_prompt(self.tools)
         self.system_message["content"] = self.prompt
                 

--- a/archytas/react.py
+++ b/archytas/react.py
@@ -119,21 +119,22 @@ class ReActAgent(Agent):
         # keep track of the last tool used (for error messages)
         self.last_tool_name = ""
 
+    def update_prompt(self):
+        tool_list = list(self.tools.values())
+        self.prompt = build_prompt(tool_list)
+        self.system_message["content"] = self.prompt
+    
     def disable(self, *tool_names):
         for tool_name in tool_names:
-            if "." not in tool_name:
-                pattern = re.compile(f"\S+\.{tool_name}$")
-                matches = list(filter(lambda name: pattern.match(name), self.tools.keys()))
+            if tool_name in self.tools:
+                self.tools.pop(tool_name)
+            elif "." not in tool_name:
+                matches = [name for name in self.tools.keys() if name.endswith(f".{tool_name}")]
                 if len(matches) > 1:
                     raise ValueError(f"Ambiguous name: Multiple tools called '{tool_name}'")
                 elif len(matches) == 1:
-                    tool_name = matches[0]
-            if tool_name in self.tools:
-                self.tools.pop(tool_name)
-            else:
-                raise AttributeError(f"Cannot disable nonexistent tool: {tool_name}")
-        self.prompt = build_prompt(self.tools)
-        self.system_message["content"] = self.prompt
+                    self.tools.pop(matches[0])
+        self.update_prompt()
                 
 
     def thought_callback(self, thought: str, tool_name: str, tool_input: str) -> None:

--- a/archytas/react.py
+++ b/archytas/react.py
@@ -127,7 +127,7 @@ class ReActAgent(Agent):
                 if len(matches) > 1:
                     raise ValueError(f"Ambiguous name: Multiple tools called '{tool_name}'")
                 elif len(matches) == 1:
-                    tool_name = matches[0].string
+                    tool_name = matches[0]
             if tool_name in self.tools:
                 self.tools.pop(tool_name)
             else:

--- a/archytas/react.py
+++ b/archytas/react.py
@@ -120,7 +120,8 @@ class ReActAgent(Agent):
 
     def disable(self, *tool_names):
         for tool_name in tool_names:
-            self.tools.pop(tool_name)
+            if tool_name in self.tools:
+                self.tools.pop(tool_name)
 
     def thought_callback(self, thought: str, tool_name: str, tool_input: str) -> None:
         if self.verbose:

--- a/archytas/react.py
+++ b/archytas/react.py
@@ -4,7 +4,6 @@ from archytas.tools import ask_user
 from archytas.tool_utils import make_tool_dict
 import asyncio
 import json
-import re
 import pdb
 import sys
 import logging

--- a/archytas/react.py
+++ b/archytas/react.py
@@ -122,6 +122,9 @@ class ReActAgent(Agent):
         for tool_name in tool_names:
             if tool_name in self.tools:
                 self.tools.pop(tool_name)
+        self.prompt = build_prompt(self.tools)
+        self.system_message["content"] = self.prompt
+                
 
     def thought_callback(self, thought: str, tool_name: str, tool_input: str) -> None:
         if self.verbose:

--- a/archytas/react.py
+++ b/archytas/react.py
@@ -118,6 +118,10 @@ class ReActAgent(Agent):
         # keep track of the last tool used (for error messages)
         self.last_tool_name = ""
 
+    def disable(self, *tool_names):
+        for tool_name in tool_names:
+            self.tools.pop(tool_name)
+
     def thought_callback(self, thought: str, tool_name: str, tool_input: str) -> None:
         if self.verbose:
             # TODO: better coloring

--- a/archytas/react.py
+++ b/archytas/react.py
@@ -124,6 +124,8 @@ class ReActAgent(Agent):
         self.system_message["content"] = self.prompt
     
     def disable(self, *tool_names):
+        if len(tool_names) == 0:
+            return
         for tool_name in tool_names:
             if tool_name in self.tools:
                 self.tools.pop(tool_name)


### PR DESCRIPTION
This PR adds a new `disable` method to the ReAct agent. `disable` takes a string, matches the name to a tool and disables it.

## Advantages
There are many different ways to accomplish tool toggling via
- a special Beaker tool function `toggleable_tool`.
- a new option `enabled` to `tool`.
- a list `disabled_tools` passed into agent initialization.

However, the `disable` has various advantages over the previous approaches:
- the feature itself has a very small footprint in terms of both LoC and actual architectural changes. 
- the agent can have its tools disabled _after_ initialization. `disable` is much more flexible.
- `disable` accepts multiple positional arguments, therefore, it can be used identically to the `disabled_tools` approach. So instead of having `super.__init__(..., disabled_tools = ["some_tool", "another_tool"] ...)`, you can explicitly put `self.disables("some_tool", "another_tool")`. I'd argue the latter is actually a bit cleaner.
- (bonus) implementing a 'reenable/toggle' for tools is very trivial

TL;DR: The `disable` method is the simplest approach without sacrificing flexibility