### PR TITLE
Add `message_history` to both ReAct and Agent classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ some_tools = [PythonTool, ..., etc.]
 agent = ReActAgent(tools=some_tools, verbose=True)
 
 # REPL to interact with agent
-for query in REPL()
+for query in REPL():
     try:
         answer = agent.react(query)
         print(answer)

--- a/archytas/agent.py
+++ b/archytas/agent.py
@@ -107,7 +107,7 @@ class Agent:
         spinner: Callable[[], ContextManager] | None = cli_spinner,
         rich_print: bool = True,
         verbose: bool = False,
-        message_history: Optional[list[Message]] | None = None,
+        messages: Optional[list[Message]] | None = None,
     ):
         """
         Agent class for managing communication with OpenAI's API.
@@ -119,7 +119,7 @@ class Agent:
             spinner ((fn -> ContextManager) | None, optional): A function that returns a context manager that is run every time the LLM is generating a response. Defaults to cli_spinner which is used to display a spinner in the terminal.
             rich_print (bool, optional): Whether to use rich to print messages. Defaults to True. Can also be set via the DISABLE_RICH_PRINT environment variable.
             verbose (bool, optional): Expands the debug output. Includes full query context on requests to the LLM. Defaults to False.
-            message_history (list[Message], optional): A list of messages to initialize the agent's conversation history with. Defaults to an empty list.
+            messages (list[Message], optional): A list of messages to initialize the agent's conversation history with. Defaults to an empty list.
 
         Raises:
             Exception: If no API key is given.
@@ -131,8 +131,7 @@ class Agent:
         self.verbose = verbose
         self.model = model
         self.system_message = Message(role=Role.system, content=prompt)
-        self.message_history = message_history if message_history is not None else []
-        self.messages: list[Message] = self.message_history
+        self.messages: list[Message] = messages if messages is not None else []
         if spinner is not None and self.rich_print:
             self.spinner = spinner
         else:
@@ -167,9 +166,6 @@ class Agent:
         Function at this level so it can be overridden in a subclass.
         """
         logger.debug(event_type, content)
-
-    def get_message_history(self):
-        return self.message_history        
 
     def new_context_id(self) -> int:
         """Generate a new context id."""

--- a/archytas/react.py
+++ b/archytas/react.py
@@ -70,6 +70,7 @@ class ReActAgent(Agent):
         max_errors: int | None = 3,
         max_react_steps: int | None = None,
         thought_handler: typing.Callable | None = Undefined,
+        message_history: typing.Optional[list[Message]] | None = None,
         **kwargs,
     ):
         """
@@ -84,8 +85,8 @@ class ReActAgent(Agent):
             max_react_steps (int, optional): The maximum number of steps to allow during a task. Defaults to infinity.
             thought_handler (function, optional): Hook to control logging/output of the thoughts made in the middle of a react loop. Set to None to disable, or leave default of Undefined to
                     print to terminal. Otherwise expects a callable function with the signature of `func(thought: str, tool_name: str, tool_input: str) -> None`.
+            message_history (list[Message], optional): A list of messages to start the agent with. Defaults to None.
         """
-
         # create a dictionary for looking up tools by name
         tools = tools or []
         if allow_ask_user:
@@ -106,9 +107,12 @@ class ReActAgent(Agent):
             names == keys
         ), f"Internal Error: tools dict keys does not match list of generated tool names. {names} != {keys}"
 
+        # Set up message history
+        self.message_history = message_history if message_history is not None else []  # Default to empty list if None
+
         # create the prompt with the tools, and initialize the agent
         self.prompt = build_prompt(tools)
-        super().__init__(model=model, prompt=self.prompt, api_key=api_key, **kwargs)
+        super().__init__(model=model, prompt=self.prompt, api_key=api_key, message_history=self.message_history, **kwargs)
 
         # react settings
         self.max_errors = max_errors or float("inf")

--- a/archytas/react.py
+++ b/archytas/react.py
@@ -70,7 +70,7 @@ class ReActAgent(Agent):
         max_errors: int | None = 3,
         max_react_steps: int | None = None,
         thought_handler: typing.Callable | None = Undefined,
-        message_history: typing.Optional[list[Message]] | None = None,
+        messages: typing.Optional[list[Message]] | None = None,
         **kwargs,
     ):
         """
@@ -85,7 +85,7 @@ class ReActAgent(Agent):
             max_react_steps (int, optional): The maximum number of steps to allow during a task. Defaults to infinity.
             thought_handler (function, optional): Hook to control logging/output of the thoughts made in the middle of a react loop. Set to None to disable, or leave default of Undefined to
                     print to terminal. Otherwise expects a callable function with the signature of `func(thought: str, tool_name: str, tool_input: str) -> None`.
-            message_history (list[Message], optional): A list of messages to start the agent with. Defaults to None.
+            messages (list[Message], optional): A list of messages to start the agent with. Defaults to None.
         """
         # create a dictionary for looking up tools by name
         tools = tools or []
@@ -107,12 +107,9 @@ class ReActAgent(Agent):
             names == keys
         ), f"Internal Error: tools dict keys does not match list of generated tool names. {names} != {keys}"
 
-        # Set up message history
-        self.message_history = message_history if message_history is not None else []  # Default to empty list if None
-
         # create the prompt with the tools, and initialize the agent
         self.prompt = build_prompt(tools)
-        super().__init__(model=model, prompt=self.prompt, api_key=api_key, message_history=self.message_history, **kwargs)
+        super().__init__(model=model, prompt=self.prompt, api_key=api_key, messages=messages, **kwargs)
 
         # react settings
         self.max_errors = max_errors or float("inf")


### PR DESCRIPTION
This PR implements a `message_history` argument for the `Agent` and `ReActAgent` classes. You can initialize an agent using a `message_history` which can be dumped with `Agent.message_history` (or `Agent.messages`) and you can initialize the agent with the `optional` `message_history` argument.

To test this, you can run a trial agent. Try commenting / uncommenting the `agent = ` lines to see the difference between the two agents:

```
from archytas.react import ReActAgent, FailedTaskError
from archytas.tools import PythonTool

from easyrepl import REPL

# message history
message_history = [{'role': 'user', 'content': 'what is 2+2?'}, {'role': 'assistant', 'content': '{\n  "thought": "I need to use the PythonTool to calculate the sum of 2 and 2.",\n  "tool": "PythonTool.run",\n  "tool_input": "print(2+2)"\n}'}, {'role': 'system', 'content': '4\n'}, {'role': 'assistant', 'content': '{\n  "thought": "The calculation is complete and the result is 4.",\n  "tool": "final_answer",\n  "tool_input": "2 + 2 equals 4."\n}'}, {'role': 'user', 'content': 'test'}, {'role': 'assistant', 'content': '{\n  "thought": "The user input \'test\' is not a clear task or question. I should ask for clarification.",\n  "tool": "ask_user",\n  "tool_input": "Could you please provide more details or clarify what you would like to test?"\n}'}, {'role': 'system', 'content': 'oh nothing at all. can you tell me a funny word?'}, {'role': 'assistant', 'content': '{\n  "thought": "The user is asking for a funny word. I\'ll provide one that is often found amusing.",\n  "tool": "final_answer",\n  "tool_input": "Bamboozled is a funny word."\n}'}]

# create the agent with the tools list
some_tools = [PythonTool]

# TEST: comment the first `agent` implementation and uncomment the 2nd one to have an agent with a message
# history. You can ask it something like "what did we last discuss?" to assess both agents
agent = ReActAgent(tools=some_tools, verbose=True)
# agent = ReActAgent(tools=some_tools, verbose=True, message_history=message_history)

# REPL to interact with agent
for query in REPL():
    try:
        answer = agent.react(query)
        print(answer)
    except FailedTaskError as e:
        print(f"Error: {e}")
```

In general I'm very open to suggestions on if there are more elegant or efficient ways to implement this--I thought having a new argument called `message_history` is more explicit than just accepting something called `messages` at init, but again open to feedback.