### PR TITLE
Add log function to distinguish debug and log levels to be overridden

### DIFF
--- a/archytas/agent.py
+++ b/archytas/agent.py
@@ -190,6 +190,9 @@ class Agent:
         """
         logger.debug(event_type, content)
 
+    def log(self, event_type: str, content: Any) -> None:
+        logger.info(event_type, content)
+
     def set_openai_key(self, key):
         import openai
         from .models.openai import OpenAIModel

--- a/archytas/react.py
+++ b/archytas/react.py
@@ -346,7 +346,7 @@ class ReActAgent(Agent):
                             "react_context": react_context,
                         }
                         tool_self_ref = getattr(tool_fn, "__self__", None)
-                        self.debug(
+                        self.log(
                             event_type="react_tool",
                             content={
                                 "tool": tool_name,
@@ -354,7 +354,7 @@ class ReActAgent(Agent):
                             }
                         )
                         tool_output = await tool_fn.run(args=tool_args, tool_context=tool_context, self_ref=tool_self_ref)
-                        self.debug(
+                        self.log(
                             event_type="react_tool_output",
                             content={
                                 "tool": tool_name,


### PR DESCRIPTION
Rather than only have debug to be overridden by things inheriting from Agent, add logging as well to be used in Beaker.

Change tool use and output to a higher level of importance than debug.