### PR TITLE
Update ReAct prompt and make it customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ from archytas.tools import PythonTool
 
 from easyrepl import REPL
 
-# create the agent with the tools list
+# create the agent with the tools list or a `custom_prelude` (if desired)
 some_tools = [PythonTool, ..., etc.]
 agent = ReActAgent(tools=some_tools, verbose=True)
 

--- a/archytas/prompt.py
+++ b/archytas/prompt.py
@@ -5,26 +5,6 @@ from .message_schemas import ToolUseRequest
 
 tool_use_schema = json.dumps(ToolUseRequest.model_json_schema(), indent=2)
 
-def prelude() -> str:
-    return f'''\
-You are the ReAct (Reason & Action) assistant. You act as an interface between a user and the system.
-
-Your job is to help the user complete their tasks by calling the appropriate tools, evaluating results, and communicating effectively.
-
-Key principles:
-1. Focus precisely on what the user has asked for - no more, no less
-2. Use tools as needed to fulfill the request - multiple tools are fine when necessary
-3. Be efficient but thorough in addressing the specific request
-4. Don't expand the scope beyond the user's explicit question
-
-The user may not see the results of executing the tools, so communicate important results/outputs from tool executions. Only run one tool at a time and review the output before proceeding.
-
-You can provide your thoughts via response text separate from calling a tool, explaining your reasoning when it adds clarity. The user may or may not see these thoughts.
-
-Remember: Your goal is to solve exactly what was asked. For example, if asked for a mean, provide the mean - don't generate additional visualizations or analyses unless specifically requested.
-'''
-
-
 def tool_intro() -> str:
     return "# Tools\nYou have access to the following tools which can help you in your job:"
 
@@ -97,7 +77,7 @@ def notes(*, ask_user: bool) -> str:
 """.strip()
 
 
-def build_prompt(tools: list[Callable]) -> str:
+def build_prompt(custom_prelude: str = None) -> str:
     """
     Build the prompt for the ReAct agent
 
@@ -107,21 +87,10 @@ def build_prompt(tools: list[Callable]) -> str:
     Returns:
         str: The prompt for the ReAct agent
     """
-    # collect all the tool names (including class.method names)
-    # tool_names = build_all_tool_names(tools)
-
-    # # check if the ask user prompt is in the list of tools
-    # ask_user = "ask_user" in tool_names
-
-    # chunks = [prelude(), tool_intro()]
-    # for tool in tools:
-    #     chunks.append(get_tool_prompt_description(tool))
-    # chunks.append(system_tools() + "\n")
-    # chunks.append(formatting(tool_names, ask_user=ask_user) + "\n")
-    # chunks.append(notes(ask_user=ask_user))
-    # return "\n\n".join(chunks)
-    # return prelude()
-    return f'''\
+    if custom_prelude is not None:
+        prelude = custom_prelude
+    else:
+        prelude = f'''\
 You are the ReAct (Reason & Action) assistant. You act as an interface between a user and the system.
 
 Your job is to help the user complete their tasks by calling the appropriate tools, evaluating results, and communicating effectively.
@@ -138,6 +107,7 @@ You can provide your thoughts via response text separate from calling a tool, ex
 
 Remember: Your goal is to solve exactly what was asked. For example, if asked for a mean, provide the mean - don't generate additional visualizations or analyses unless specifically requested.
 '''
+    return prelude
 
 
 def build_all_tool_names(tools: list[Callable]) -> list[str]:

--- a/archytas/prompt.py
+++ b/archytas/prompt.py
@@ -9,18 +9,19 @@ def prelude() -> str:
     return f'''\
 You are the ReAct (Reason & Action) assistant. You act as an interface between a user and the system.
 
-Your job is to help the user to complete their tasks by calling tools, evaluating the results and communicating with the user.
-The user will communicate with you directly in natural language, however you can only respond to queries by calling tools.
-Calling tools requires that you respond with properly formatted JSON objects that fit the schema described below.
-As the only action you can take is to call a tool, this means that every response you make must be a JSON object.
-Any plain text not part of a JSON object will be ignored or will cause errors.
+Your job is to help the user complete their tasks by calling the appropriate tools, evaluating results, and communicating effectively.
 
-You will be provided tools that will allow communication with the user. All communication should be done via those tools.
+Key principles:
+1. Focus precisely on what the user has asked for - no more, no less
+2. Use tools as needed to fulfill the request - multiple tools are fine when necessary
+3. Be efficient but thorough in addressing the specific request
+4. Don't expand the scope beyond the user's explicit question
 
-Completing the user's task may require calling several tools in a chain or loop. This is fine. You can call as many tools
-as you feel is necessary to complete the task, within reason. If you cannot make progress towards the task, or if calling
-the provided tools is not getting you closer to completing the task, you should communcate this to the user by failing the
-task. Only ever run one tool at a time and review the output of running the tool before deciding upon the next tool to call.
+The user may not see the results of executing the tools, so communicate important results/outputs from tool executions. Only run one tool at a time and review the output before proceeding.
+
+You can provide your thoughts via response text separate from calling a tool, explaining your reasoning when it adds clarity. The user may or may not see these thoughts.
+
+Remember: Your goal is to solve exactly what was asked. For example, if asked for a mean, provide the mean - don't generate additional visualizations or analyses unless specifically requested.
 '''
 
 
@@ -123,17 +124,19 @@ def build_prompt(tools: list[Callable]) -> str:
     return f'''\
 You are the ReAct (Reason & Action) assistant. You act as an interface between a user and the system.
 
-Your job is to help the user to complete their tasks by calling tools, evaluating the results and communicating with the user.
-The user may not see the results of executing the tools, so be sure to communicate the important results/outputs from the tool
-executions back to the user following the execution.
+Your job is to help the user complete their tasks by calling the appropriate tools, evaluating results, and communicating effectively.
 
-Completing the user's task may require calling several tools in a chain or loop. This is fine. You can call as many tools
-as you feel is necessary to complete the task, within reason. If you cannot make progress towards the task, or if calling
-the provided tools is not getting you closer to completing the task, you should communcate this to the user by failing the
-task. Only ever run one tool at a time and review the output of running the tool before deciding upon the next tool to call.
+Key principles:
+1. Focus precisely on what the user has asked for - no more, no less
+2. Use tools as needed to fulfill the request - multiple tools are fine when necessary
+3. Be efficient but thorough in addressing the specific request
+4. Don't expand the scope beyond the user's explicit question
 
-If you are able to provide your thoughts via response text separate from calling a tool. Please do so, explaining your thoughts
-as to reasoning behind the call. The user may or may not see these thoughts.
+The user may not see the results of executing the tools, so communicate important results/outputs from tool executions. Only run one tool at a time and review the output before proceeding.
+
+You can provide your thoughts via response text separate from calling a tool, explaining your reasoning when it adds clarity. The user may or may not see these thoughts.
+
+Remember: Your goal is to solve exactly what was asked. For example, if asked for a mean, provide the mean - don't generate additional visualizations or analyses unless specifically requested.
 '''
 
 


### PR DESCRIPTION
This PR cleans up the `prompt.py` file and updates the `ReActAgent` to accept a `custom_prelude`. If none is provided it defaults to the hardcoded one in `prompt.py`. So you can instantiate your agent like:

```
agent = ReActAgent(tools=some_tools, verbose=True, custom_prelude="AHOY THERE!")
```

I tested this in Beaker's default context. Since the `BeakerAgent` accepts `**kwargs` you can just do something like:

```
class DefaultAgent(BeakerAgent):
    """
    You are an programming assistant to aid a developer working in a Jupyter notebook by answering their questions and helping write code for them based on their
    prompt.
    """
    def __init__(self, context=None, tools=None, custom_prelude=None, **kwargs):
        super().__init__(context=context, tools=tools, custom_prelude="AHOY THERE!", **kwargs)  
```

and then you'll see that the prelude is `AHOY THERE!`....for better or worse 🏴‍☠️ 

This does include the updated base prompt as well--which we should note does seem to reduce the iterations in ReAct loops in general for the Archytas agent. I am not so worried about this now that it can be specified at the level of the Beaker context though.