### PR TITLE
Implementation of ensure_async utility

### DIFF
--- a/archytas/chat_history.py
+++ b/archytas/chat_history.py
@@ -17,6 +17,7 @@ from pydantic import Field
 
 from .exceptions import AuthenticationError, ExecutionError, ModelError, ContextWindowExceededError
 from .models.base import BaseArchytasModel
+from .utils import ensure_async
 
 from .exceptions import AuthenticationError
 from .summarizers import (
@@ -64,10 +65,7 @@ class AutoContextMessage(ContextMessage):
 
     async def update_content(self):
         orig_hash = self.content_hash
-        if inspect.iscoroutinefunction(self.content_updater):
-            result = await self.content_updater()
-        else:
-            result = self.content_updater()
+        result = await ensure_async(self.content_updater())
         self.content = result
         if self.content_hash != orig_hash and self._model:
             print("Need to update count")

--- a/archytas/tool_utils.py
+++ b/archytas/tool_utils.py
@@ -6,6 +6,7 @@ from .agent import Agent
 from .archytypes import evaluate_type_str, normalize_type, NormalizedType, is_primitive_type, is_structured_type
 from .structured_data_utils import get_structured_input_description, construct_structured_type
 from .summarizers import default_tool_summarizer
+from .utils import ensure_async
 
 from types import NoneType
 from typing import Callable, Any, ParamSpec, TypeVar, overload, Optional, TYPE_CHECKING
@@ -157,10 +158,7 @@ def tool(
                 if context_value:
                     kwargs[inj_name] = context_value
 
-            if inspect.iscoroutinefunction(func):
-                result = await func(*pargs, **kwargs)
-            else:
-                result = func(*pargs, **kwargs)
+            result = await ensure_async(func(*pargs, **kwargs))
 
             # convert the result to a string if it is not already a string
             if not isinstance(result, str):

--- a/archytas/utils.py
+++ b/archytas/utils.py
@@ -1,8 +1,9 @@
+import inspect
 import json
 import re
 from json.decoder import JSONDecoder
 from types import GenericAlias, UnionType
-from typing import Any, Union, get_origin, get_args as get_type_args
+from typing import Any, Union, get_origin, get_args as get_type_args, Coroutine, Callable
 
 json_regex = re.compile(r'(```)(json)?(.*?)(```)')
 
@@ -52,3 +53,10 @@ class InstanceMethod:
                 "This method should only be accessed from an instance of the class"
             )
         return self.func.__get__(instance, owner)
+
+
+async def ensure_async(fn: Coroutine|Callable):
+    if inspect.iscoroutine(fn) or inspect.iscoroutinefunction(fn):
+        return await fn
+    else:
+        return fn


### PR DESCRIPTION
Helper function that works allows wrapping calls so that they can be awaited regardless if they are async/coroutine functions or normal/blocking functions.