### PR TITLE
make exceptions get printed out during react loop

### DIFF
--- a/archytas/react.py
+++ b/archytas/react.py
@@ -427,6 +427,8 @@ class ReActAgent(Agent):
                             tool_call_id=tool_id
                         ))
                         self.chat_history.current_loop_id = None
+                        if self.verbose:
+                            self.print(f"[red]Exception raised in tool: '{tool_name}'[/red]\n[yellow]{''.join(traceback.format_exception(e))}[/yellow]")
 
             # Execute to fetch next step in the ReAct loop
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "archytas"
-version = "1.4.0"
+version = "1.4.1"
 description = "A library for pairing LLM agents with tools so they perform open ended tasks"
 authors = ["David Andrew Samson <david.andrew.engineer@gmail.com>", "Matthew Printz <matt@jataware.com>"]
 readme = "README.md"


### PR DESCRIPTION
short term solution to the regression introduced in https://github.com/jataware/archytas/pull/42/commits/377ec2f8add22cfde1f336be73eaccc4cdb7846d which removed printing out exceptions when they happen. See old example: https://github.com/jataware/archytas/blob/75ed42a2a78f6b593a2bc3a898124d531ab27235/archytas/react.py#L306

Longer term fix probably would involve reworking the `ReActAgent.error` method and using that in select locations: https://github.com/jataware/archytas/blob/main/archytas/react.py#L479-L492