### PR TITLE
Workaround for o3 and o4 openai model context window

### DIFF
--- a/archytas/models/openai.py
+++ b/archytas/models/openai.py
@@ -87,4 +87,6 @@ class OpenAIModel(BaseArchytasModel):
         except ValueError as err:
             if 'gpt-4.1' in model_name:
                 return 1_000_000
+            elif model_name.startswith('o3'):
+                return 200_000
             raise

--- a/archytas/models/openai.py
+++ b/archytas/models/openai.py
@@ -87,6 +87,6 @@ class OpenAIModel(BaseArchytasModel):
         except ValueError as err:
             if 'gpt-4.1' in model_name:
                 return 1_000_000
-            elif model_name.startswith('o3'):
+            elif model_name.startswith(('o3', 'o4')):
                 return 200_000
             raise


### PR DESCRIPTION
o3, o3-mini and o4-mini all have a 200k token context window