### PR TITLE
Bedrock fixes (context size and permissions check)

### DIFF
--- a/archytas/models/bedrock.py
+++ b/archytas/models/bedrock.py
@@ -93,6 +93,12 @@ class BedrockModel(BaseArchytasModel):
 
         model = self.config.model_name or self.DEFAULT_MODEL
 
+        # Check permissions early - warn if missing but don't fail
+        try:
+            self._check_service_quotas_permission()
+        except AuthenticationError as e:
+            logging.warning(f"AWS ListServiceQuotas permission missing - using default token limits: {e}")
+
         if self.credentials_profile_name:
             return ChatBedrockConverse(
                 credentials_profile_name=self.credentials_profile_name,
@@ -163,9 +169,6 @@ class BedrockModel(BaseArchytasModel):
 
     @lru_cache()
     def contextsize(self, model_name = None):
-        # Check permissions first - fail fast if missing
-        self._check_service_quotas_permission()
-        
         # Reasonable but small default
         limit = 50_000
 


### PR DESCRIPTION
This PR bumps the context limit default to 50,000 tokens from 20,000 tokens. It also adds a `_check_service_quotas_permission` function which is invoked on init of the agent. In case the permissions aren't set on the available tokens the following will happen:

1. On init there will be a `WARNING`

```
WARNING - AWS ListServiceQuotas permission missing - using default token limits: AWS credentials lack ListServiceQuotas permission. This is required for Bedrock token limits. Error: An error occurred (AccessDeniedException) when calling the ListServiceQuotas operation: User: arn:aws-us-gov:iam::414431045213:user/onr01-bedrock-invoker-temp is not authorized to perform: servicequotas:ListServiceQuotas because no identity-based policy allows the servicequotas:ListServiceQuotas action
```

2. When `contextsize()` is triggered, an `INFO` will be thrown and the default `limit` (now set to `50_000`) will be returned 

```
INFO - BedrockModel.contextsize: Skipping AWS quota lookup (no permissions), using default limit: 50000
```

3. Note that the system handles all this gracefully--previously it failed silently on failure to initialize the `quota_service`

