### PR TITLE
fix formatting of tool schemas for openrouter 

### DIFF
--- a/archytas/models/openrouter.py
+++ b/archytas/models/openrouter.py
@@ -55,8 +55,11 @@ class ChatOpenRouter:
                 'function': {
                     'name': tool.name,
                     'description': tool.description,
-                    'parameters': langchain_schema['properties'],
-                    'required': langchain_schema['required'],
+                    'parameters': {
+                        'type': 'object',
+                        'properties': langchain_schema['properties'],
+                        'required': langchain_schema['required']
+                    },
                 }
             }
             self._schemas.append(schema)
@@ -191,8 +194,6 @@ class OpenRouterModel(BaseArchytasModel):
 
     def initialize_model(self, **kwargs):  # pyright: ignore[reportIncompatibleMethodOverride]
         model_name = getattr(self.config, "model_name", None) or self.DEFAULT_MODEL
-        if model_name.startswith('openai/'):
-            logger.warning(f"Tool support for OpenAI models on OpenRouter via toki has been buggy. Detected model '{model_name}'. Recommend using the archytas OpenAIModel backend instead of OpenRouter.")
         return ChatOpenRouter(model=str(model_name), api_key=self.api_key)
 
     async def get_num_tokens_from_messages(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archytas"
-version = "1.6.1"
+version = "1.6.2"
 description = "A library for pairing LLM agents with tools so they perform open ended tasks"
 authors = [
     {name = "David Andrew Samson", email = "david.andrew.engineer@gmail.com"},


### PR DESCRIPTION
This fixes the step transforming Archytas/LangChain tool schemas into the openrouter format.
this should fix the issues using openai models via the openrouter backend