### PR TITLE
handle langchain tool schema inconsistencies across langchain versions

### DIFF
--- a/archytas/models/openrouter.py
+++ b/archytas/models/openrouter.py
@@ -58,7 +58,7 @@ class ChatOpenRouter:
                     'parameters': {
                         'type': 'object',
                         'properties': langchain_schema['properties'],
-                        'required': langchain_schema['required']
+                        'required': langchain_schema.get('required', [])
                     },
                 }
             }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archytas"
-version = "1.6.2"
+version = "1.6.3"
 description = "A library for pairing LLM agents with tools so they perform open ended tasks"
 authors = [
     {name = "David Andrew Samson", email = "david.andrew.engineer@gmail.com"},


### PR DESCRIPTION

fixed apparent bug caused by newer versions of langchain omitting tool schema 'required' field if there are no parameters