### PR TITLE
No `thought` in tool calls

### DIFF
--- a/archytas/models/openrouter.py
+++ b/archytas/models/openrouter.py
@@ -169,7 +169,7 @@ class ChatOpenRouter:
         }
 
         if isinstance(response, dict):
-            return AIMessage(content=response['thought'], tool_calls=list(map(to_langchain_tool_call, response['tool_calls'])), usage_metadata=usage_metadata)
+            return AIMessage(content=response.get('thought') or "", tool_calls=list(map(to_langchain_tool_call, response['tool_calls'])), usage_metadata=usage_metadata)
 
         return AIMessage(content=response, usage_metadata=usage_metadata)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archytas"
-version = "1.6.9"
+version = "1.6.10"
 description = "A library for pairing LLM agents with tools so they perform open ended tasks"
 authors = [
     {name = "David Andrew Samson", email = "david.andrew.engineer@gmail.com"},


### PR DESCRIPTION
this PR fixes the openrouter backend for cases when models call a tool without providing a thought. Before, archytas would just raise an exception, whereas now the thought field is replaced with an empty string if it is not present