### PR TITLE
Round-trippable chat-history serde (closes #81)

### DIFF
--- a/archytas/chat_history.py
+++ b/archytas/chat_history.py
@@ -10,10 +10,11 @@ import warnings
 from dataclasses import MISSING
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field as dataclass_field
-from typing import TYPE_CHECKING,Callable, Collection, Optional, TypeVar, Generic, cast, Any, TypeAlias, Coroutine
+from typing import TYPE_CHECKING,Callable, Collection, Mapping, Optional, TypeVar, Generic, cast, Any, TypeAlias, Coroutine
 from typing_extensions import Self
 
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage, ToolMessage, FunctionMessage, AIMessage, ToolCall
+from langchain_core.messages import message_to_dict, messages_from_dict
 from pydantic import Field
 
 from .exceptions import AuthenticationError, ExecutionError, ModelError, ContextWindowExceededError
@@ -216,6 +217,96 @@ class AgentResponse:
     metadata: dict = dataclass_field(default_factory=dict)
 
 
+# ----------------------------------------------------------------------------
+# Serialization (serde) schema registry.
+#
+# Each serialized document/record carries a reified `SerdeSchema` — a named,
+# versioned descriptor that can be inspected, compared, and embedded in the
+# JSON. The intent is to decouple two independently-evolving concerns:
+#
+#   * The *envelope* schema (record/document structure: uuid, token_count,
+#     metadata, which lists exist, etc.). Versioned by RECORD_*_SCHEMA /
+#     CHAT_HISTORY_SCHEMA.
+#   * The *message body* format — how a LangChain `BaseMessage` is turned into
+#     JSON. Versioned separately by MESSAGE_FORMAT and stamped onto every
+#     record as a `message_format` marker. If LangChain's wire format drifts,
+#     only MESSAGE_FORMAT needs to move; the envelope versions stay put.
+# ----------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class SerdeSchema:
+    """A reified, comparable description of a serialization format.
+
+    Instances are hashable/comparable (frozen dataclass), serialize to a small
+    inspectable dict via :meth:`to_dict`, and support compatibility checks via
+    :meth:`is_compatible`.
+    """
+    name: str
+    version: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"schema": self.name, "version": self.version}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "SerdeSchema":
+        return cls(name=str(data["schema"]), version=int(data["version"]))
+
+    def is_compatible(self, other: "SerdeSchema") -> bool:
+        """Two schemas are compatible when they name the same format at the
+        same major version. (Versioning is currently a single integer, so this
+        is exact-match; widen here if minor/forward-compatible versions land.)
+        """
+        return self.name == other.name and self.version == other.version
+
+
+# Inner message-body format marker (LangChain `message_to_dict`/`messages_from_dict`).
+MESSAGE_FORMAT = SerdeSchema(name="archytas.message.langchain", version=1)
+
+# Envelope schemas for each record/document type.
+MESSAGE_RECORD_SCHEMA = SerdeSchema(name="archytas.MessageRecord", version=1)
+SUMMARY_RECORD_SCHEMA = SerdeSchema(name="archytas.SummaryRecord", version=1)
+CHAT_HISTORY_SCHEMA = SerdeSchema(name="archytas.ChatHistory", version=1)
+
+
+def _serialize_message(message: BaseMessage) -> dict[str, Any]:
+    """Convert a LangChain message to a JSON-compatible dict."""
+    return message_to_dict(message)
+
+
+def _deserialize_message(data: Mapping[str, Any]) -> BaseMessage:
+    """Reconstruct a LangChain message from its serialized dict form."""
+    return messages_from_dict([dict(data)])[0]
+
+
+def _read_schema(data: Mapping[str, Any], key: str = "format") -> Optional[SerdeSchema]:
+    """Extract the embedded :class:`SerdeSchema` from a serialized payload, if present."""
+    raw = data.get(key)
+    if not raw:
+        return None
+    return SerdeSchema.from_dict(raw)
+
+
+def _check_schema(data: Mapping[str, Any], expected: SerdeSchema, key: str = "format") -> None:
+    """Warn (do not raise) when a payload's declared schema is unknown or drifts.
+
+    Deserialization stays lenient so that older/newer envelopes can still be
+    loaded best-effort; the warning makes the drift visible for inspection.
+    """
+    found = _read_schema(data, key=key)
+    if found is None:
+        warnings.warn(
+            f"Serialized payload is missing a '{key}' schema marker; "
+            f"expected {expected.to_dict()}. Attempting to load anyway.",
+            stacklevel=3,
+        )
+    elif not found.is_compatible(expected):
+        warnings.warn(
+            f"Serialized payload schema {found.to_dict()} is not compatible with "
+            f"expected {expected.to_dict()}. Attempting to load anyway.",
+            stacklevel=3,
+        )
+
+
 @dataclass
 class MessageRecord(Generic[MessageType]):
     message: MessageType
@@ -224,11 +315,78 @@ class MessageRecord(Generic[MessageType]):
     metadata: dict[str, Any] = dataclass_field(default_factory=lambda: {})
     react_loop_id: Optional[int] = dataclass_field(default=None)
 
+    @classmethod
+    def _record_schema(cls) -> SerdeSchema:
+        """The envelope schema for this record type. Overridden by subclasses."""
+        return MESSAGE_RECORD_SCHEMA
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this record to a JSON-compatible dict.
+
+        The result carries the envelope ``format`` schema and an inner
+        ``message_format`` marker for the LangChain message body.
+        """
+        return {
+            "format": self._record_schema().to_dict(),
+            "message_format": MESSAGE_FORMAT.to_dict(),
+            "uuid": self.uuid,
+            "token_count": self.token_count,
+            "metadata": copy.deepcopy(self.metadata),
+            "react_loop_id": self.react_loop_id,
+            "message": _serialize_message(self.message),
+        }
+
+    @classmethod
+    def _common_kwargs(cls, data: Mapping[str, Any]) -> dict[str, Any]:
+        """Parse the fields shared by every record type from a serialized dict."""
+        _check_schema(data, key="message_format", expected=MESSAGE_FORMAT)
+        return {
+            "message": _deserialize_message(data["message"]),
+            "uuid": data["uuid"],
+            "token_count": data.get("token_count"),
+            "metadata": dict(data.get("metadata") or {}),
+            "react_loop_id": data.get("react_loop_id"),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "MessageRecord":
+        """Reconstruct a record from its serialized dict form.
+
+        When invoked on the base class against a payload that declares a
+        subclass schema (e.g. a :class:`SummaryRecord`), dispatches to that
+        subclass so a heterogeneous list can be loaded through one entry point.
+        """
+        schema = _read_schema(data)
+        if cls is MessageRecord and schema is not None and schema.name == SUMMARY_RECORD_SCHEMA.name:
+            return SummaryRecord.from_dict(data)
+        _check_schema(data, expected=cls._record_schema())
+        return cls(**cls._common_kwargs(data))
+
 
 @dataclass
 class SummaryRecord(MessageRecord[SystemMessage]):
     message: SystemMessage
     summarized_messages: set[str] = dataclass_field(default_factory=lambda: set())
+
+    @classmethod
+    def _record_schema(cls) -> SerdeSchema:
+        return SUMMARY_RECORD_SCHEMA
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize, carrying ``summarized_messages`` as a (sorted) list across
+        the JSON boundary; :meth:`from_dict` restores it to a set."""
+        data = super().to_dict()
+        data["summarized_messages"] = sorted(self.summarized_messages)
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "SummaryRecord":
+        _check_schema(data, expected=cls._record_schema())
+        kwargs = cls._common_kwargs(data)
+        return cls(
+            summarized_messages=set(data.get("summarized_messages") or []),
+            **kwargs,
+        )
 
 
 RecordType: TypeAlias = MessageRecord | SummaryRecord
@@ -709,3 +867,84 @@ class ChatHistory:
         record = MessageRecord(message=message, token_count=token_count, react_loop_id=self.current_loop_id)
         self.raw_records.append(record)
         return record
+
+    # ------------------------------------------------------------------
+    # Serialization (serde)
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this chat history to a JSON-compatible aggregate document.
+
+        The document carries the :data:`CHAT_HISTORY_SCHEMA` envelope marker,
+        the raw message records, the summary records, and a block of useful
+        (non-reconstructive) metadata describing the model and token budget.
+
+        The model itself and runtime-only state (summarizers, in-flight
+        summarization task, last sent messages) are intentionally not
+        serialized; provide a live ``model``/summarizers to :meth:`from_dict`.
+        """
+        model_meta: Optional[dict[str, Any]] = None
+        if self.model is not None:
+            try:
+                context_window = self.model.contextsize()
+            except Exception:
+                context_window = None
+            model_meta = {
+                "class": type(self.model).__name__,
+                "model_name": getattr(self.model, "model_name", None),
+                "context_window": context_window,
+            }
+
+        return {
+            "format": CHAT_HISTORY_SCHEMA.to_dict(),
+            "metadata": {
+                "model": model_meta,
+                "current_loop_id": self.current_loop_id,
+                "summarization_threshold": self.summarization_threshold,
+                "tool_token_estimate": self.tool_token_estimate,
+                "token_estimate": self._token_estimate,
+            },
+            "raw_records": [record.to_dict() for record in self.raw_records],
+            "summaries": [summary.to_dict() for summary in self.summaries],
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: Mapping[str, Any],
+        model: Optional[BaseArchytasModel] = None,
+        loop_summarizer: Optional[callable] = default_loop_summarizer,
+        history_summarizer: Optional[callable] = default_history_summarizer,
+    ) -> "ChatHistory":
+        """Reconstruct a :class:`ChatHistory` from :meth:`to_dict` output.
+
+        ``uuid``s on every record are preserved unchanged, and
+        :class:`SummaryRecord`s are restored with their ``summarized_messages``
+        sets intact. A live ``model`` and summarizers may be supplied since they
+        are not part of the serialized document.
+        """
+        _check_schema(data, expected=CHAT_HISTORY_SCHEMA)
+
+        history = cls(
+            model=model,
+            loop_summarizer=loop_summarizer,
+            history_summarizer=history_summarizer,
+        )
+        history.raw_records = [
+            MessageRecord.from_dict(record) for record in data.get("raw_records", [])
+        ]
+        history.summaries = [
+            SummaryRecord.from_dict(summary) for summary in data.get("summaries", [])
+        ]
+
+        metadata = data.get("metadata") or {}
+        if metadata.get("current_loop_id") is not None:
+            history.current_loop_id = metadata["current_loop_id"]
+        if metadata.get("summarization_threshold") is not None:
+            history.summarization_threshold = metadata["summarization_threshold"]
+        if metadata.get("tool_token_estimate") is not None:
+            history.tool_token_estimate = metadata["tool_token_estimate"]
+        if metadata.get("token_estimate") is not None:
+            history._token_estimate = metadata["token_estimate"]
+
+        return history

--- a/archytas/chat_history.py
+++ b/archytas/chat_history.py
@@ -838,14 +838,14 @@ class ChatHistory:
 
     def set_system_preamble_text(self, text: str):
         """
-        Sets/updates the user_preamble
+        Sets/updates the system_preamble
 
         Set text to an empty string to remove the preamble message.
         """
         if text:
-            self.user_preamble = MessageRecord(message=SystemMessage(content=text), metadata={"preamble": True})
+            self.system_preamble = MessageRecord(message=SystemMessage(content=text), metadata={"preamble": True})
         else:
-            self.user_preamble = None
+            self.system_preamble = None
 
     def set_user_preamble_text(self, text: str):
         """
@@ -876,8 +876,11 @@ class ChatHistory:
         """Serialize this chat history to a JSON-compatible aggregate document.
 
         The document carries the :data:`CHAT_HISTORY_SCHEMA` envelope marker,
-        the raw message records, the summary records, and a block of useful
-        (non-reconstructive) metadata describing the model and token budget.
+        the system message, the system/user preambles, the raw message records,
+        the summary records, and a block of useful (non-reconstructive) metadata
+        describing the model and token budget.
+
+        The system message and preambles serialize to ``None`` when unset.
 
         The model itself and runtime-only state (summarizers, in-flight
         summarization task, last sent messages) are intentionally not
@@ -904,6 +907,9 @@ class ChatHistory:
                 "tool_token_estimate": self.tool_token_estimate,
                 "token_estimate": self._token_estimate,
             },
+            "system_message": self.system_message.to_dict() if self.system_message else None,
+            "system_preamble": self.system_preamble.to_dict() if self.system_preamble else None,
+            "user_preamble": self.user_preamble.to_dict() if self.user_preamble else None,
             "raw_records": [record.to_dict() for record in self.raw_records],
             "summaries": [summary.to_dict() for summary in self.summaries],
         }
@@ -920,8 +926,9 @@ class ChatHistory:
 
         ``uuid``s on every record are preserved unchanged, and
         :class:`SummaryRecord`s are restored with their ``summarized_messages``
-        sets intact. A live ``model`` and summarizers may be supplied since they
-        are not part of the serialized document.
+        sets intact. The system message and preambles are restored when present
+        and left unset when ``None`` or absent. A live ``model`` and summarizers
+        may be supplied since they are not part of the serialized document.
         """
         _check_schema(data, expected=CHAT_HISTORY_SCHEMA)
 
@@ -930,6 +937,15 @@ class ChatHistory:
             loop_summarizer=loop_summarizer,
             history_summarizer=history_summarizer,
         )
+
+        # System message and preambles are optional: null or absent => leave unset.
+        if data.get("system_message"):
+            history.system_message = MessageRecord.from_dict(data["system_message"])
+        if data.get("system_preamble"):
+            history.system_preamble = MessageRecord.from_dict(data["system_preamble"])
+        if data.get("user_preamble"):
+            history.user_preamble = MessageRecord.from_dict(data["user_preamble"])
+
         history.raw_records = [
             MessageRecord.from_dict(record) for record in data.get("raw_records", [])
         ]

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -1,0 +1,333 @@
+"""
+Tests for chat-history serialization/deserialization (serde).
+
+These are pure unit tests: they exercise the serde machinery on hand-built
+records and histories and require no model or API keys.
+"""
+import json
+import warnings
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+
+from archytas.chat_history import (
+    ChatHistory,
+    MessageRecord,
+    SummaryRecord,
+    SerdeSchema,
+    MESSAGE_FORMAT,
+    MESSAGE_RECORD_SCHEMA,
+    SUMMARY_RECORD_SCHEMA,
+    CHAT_HISTORY_SCHEMA,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+def build_history() -> ChatHistory:
+    """A history with a mix of message types, a summary, and populated metadata."""
+    history = ChatHistory()
+    history.current_loop_id = 7
+
+    r1 = history.add_message(HumanMessage(content="hello"))
+    r1.token_count = 5
+    r1.metadata = {"source": "user", "nested": {"k": [1, 2, 3]}}
+
+    r2 = history.add_message(
+        AIMessage(
+            content="calling a tool",
+            tool_calls=[{"name": "foo", "args": {"x": 1}, "id": "tc1"}],
+        )
+    )
+    history.add_message(ToolMessage(content="tool result", tool_call_id="tc1"))
+
+    summary = SummaryRecord(
+        message=SystemMessage(content="summary of the conversation so far"),
+        summarized_messages={r1.uuid, r2.uuid},
+    )
+    history.summaries.append(summary)
+
+    history.tool_token_estimate = 42
+    return history
+
+
+def assert_json_compatible(obj) -> dict:
+    """Round-trip through JSON and return the reloaded object."""
+    blob = json.dumps(obj)
+    return json.loads(blob)
+
+
+# ---------------------------------------------------------------------------
+# SerdeSchema (the reified versioning mechanism)
+# ---------------------------------------------------------------------------
+
+class TestSerdeSchema:
+    def test_is_inspectable_and_jsonable(self):
+        d = MESSAGE_RECORD_SCHEMA.to_dict()
+        assert d == {"schema": MESSAGE_RECORD_SCHEMA.name, "version": MESSAGE_RECORD_SCHEMA.version}
+        assert assert_json_compatible(d) == d
+
+    def test_roundtrip(self):
+        schema = SerdeSchema(name="archytas.Thing", version=3)
+        assert SerdeSchema.from_dict(schema.to_dict()) == schema
+
+    def test_frozen_and_hashable(self):
+        # frozen dataclass -> usable in sets / as dict keys, and immutable
+        s = SerdeSchema(name="a", version=1)
+        assert {s, SerdeSchema(name="a", version=1)} == {s}
+        with pytest.raises(Exception):
+            s.version = 2  # type: ignore[misc]
+
+    def test_compatibility(self):
+        assert MESSAGE_RECORD_SCHEMA.is_compatible(MESSAGE_RECORD_SCHEMA)
+        assert not MESSAGE_RECORD_SCHEMA.is_compatible(
+            SerdeSchema(name=MESSAGE_RECORD_SCHEMA.name, version=MESSAGE_RECORD_SCHEMA.version + 1)
+        )
+        assert not MESSAGE_RECORD_SCHEMA.is_compatible(SUMMARY_RECORD_SCHEMA)
+
+    def test_distinct_schemas(self):
+        names = {
+            MESSAGE_FORMAT.name,
+            MESSAGE_RECORD_SCHEMA.name,
+            SUMMARY_RECORD_SCHEMA.name,
+            CHAT_HISTORY_SCHEMA.name,
+        }
+        assert len(names) == 4
+
+
+# ---------------------------------------------------------------------------
+# MessageRecord serde
+# ---------------------------------------------------------------------------
+
+class TestMessageRecordSerde:
+    def test_carries_envelope_and_message_format_markers(self):
+        record = MessageRecord(message=HumanMessage(content="hi"))
+        d = record.to_dict()
+        assert d["format"] == MESSAGE_RECORD_SCHEMA.to_dict()
+        # inner message_format marker is independent of the envelope marker
+        assert d["message_format"] == MESSAGE_FORMAT.to_dict()
+        assert d["format"] != d["message_format"]
+
+    def test_is_json_compatible(self):
+        record = MessageRecord(
+            message=AIMessage(content="x", tool_calls=[{"name": "t", "args": {}, "id": "1"}]),
+            token_count=9,
+            metadata={"a": 1},
+            react_loop_id=3,
+        )
+        reloaded = assert_json_compatible(record.to_dict())
+        back = MessageRecord.from_dict(reloaded)
+        assert back.uuid == record.uuid
+        assert back.token_count == 9
+        assert back.metadata == {"a": 1}
+        assert back.react_loop_id == 3
+
+    def test_uuid_preserved(self):
+        record = MessageRecord(message=HumanMessage(content="hi"))
+        back = MessageRecord.from_dict(record.to_dict())
+        assert back.uuid == record.uuid
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            HumanMessage(content="plain human"),
+            SystemMessage(content="a system prompt"),
+            AIMessage(content="ai reply"),
+            AIMessage(content="", tool_calls=[{"name": "foo", "args": {"x": 1}, "id": "tc1"}]),
+            ToolMessage(content="the result", tool_call_id="tc1"),
+        ],
+    )
+    def test_message_body_roundtrips(self, message):
+        record = MessageRecord(message=message)
+        back = MessageRecord.from_dict(record.to_dict())
+        assert type(back.message) is type(message)
+        assert back.message.content == message.content
+
+    def test_tool_call_details_survive(self):
+        record = MessageRecord(
+            message=AIMessage(
+                content="",
+                tool_calls=[{"name": "foo", "args": {"x": 1, "y": "z"}, "id": "tc1"}],
+            )
+        )
+        back = MessageRecord.from_dict(record.to_dict())
+        tc = back.message.tool_calls[0]
+        assert tc["name"] == "foo"
+        assert tc["args"] == {"x": 1, "y": "z"}
+        assert tc["id"] == "tc1"
+
+    def test_metadata_is_deep_copied(self):
+        # serialization must not alias mutable metadata back to the live record
+        meta = {"nested": {"k": 1}}
+        record = MessageRecord(message=HumanMessage(content="hi"), metadata=meta)
+        d = record.to_dict()
+        d["metadata"]["nested"]["k"] = 999
+        assert record.metadata["nested"]["k"] == 1
+
+    def test_none_scalars_roundtrip(self):
+        record = MessageRecord(message=HumanMessage(content="hi"))
+        assert record.token_count is None
+        assert record.react_loop_id is None
+        back = MessageRecord.from_dict(record.to_dict())
+        assert back.token_count is None
+        assert back.react_loop_id is None
+
+
+# ---------------------------------------------------------------------------
+# SummaryRecord serde
+# ---------------------------------------------------------------------------
+
+class TestSummaryRecordSerde:
+    def test_uses_its_own_envelope_schema(self):
+        summary = SummaryRecord(message=SystemMessage(content="s"))
+        assert summary.to_dict()["format"] == SUMMARY_RECORD_SCHEMA.to_dict()
+
+    def test_summarized_messages_crosses_json_as_list(self):
+        summary = SummaryRecord(
+            message=SystemMessage(content="s"),
+            summarized_messages={"a", "b", "c"},
+        )
+        d = summary.to_dict()
+        assert isinstance(d["summarized_messages"], list)
+        # sorted for deterministic output
+        assert d["summarized_messages"] == ["a", "b", "c"]
+
+    def test_summarized_messages_restored_as_set(self):
+        summary = SummaryRecord(
+            message=SystemMessage(content="s"),
+            summarized_messages={"a", "b"},
+        )
+        back = SummaryRecord.from_dict(assert_json_compatible(summary.to_dict()))
+        assert isinstance(back.summarized_messages, set)
+        assert back.summarized_messages == {"a", "b"}
+        assert back.uuid == summary.uuid
+
+    def test_empty_summarized_messages(self):
+        summary = SummaryRecord(message=SystemMessage(content="s"))
+        back = SummaryRecord.from_dict(summary.to_dict())
+        assert back.summarized_messages == set()
+
+    def test_base_class_dispatches_to_subclass(self):
+        # MessageRecord.from_dict on a summary payload should produce a SummaryRecord
+        summary = SummaryRecord(
+            message=SystemMessage(content="s"),
+            summarized_messages={"a", "b"},
+        )
+        back = MessageRecord.from_dict(summary.to_dict())
+        assert isinstance(back, SummaryRecord)
+        assert back.summarized_messages == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# ChatHistory aggregate serde
+# ---------------------------------------------------------------------------
+
+class TestChatHistorySerde:
+    def test_document_shape(self):
+        doc = build_history().to_dict()
+        assert doc["format"] == CHAT_HISTORY_SCHEMA.to_dict()
+        assert set(doc) == {"format", "metadata", "raw_records", "summaries"}
+        assert len(doc["raw_records"]) == 3
+        assert len(doc["summaries"]) == 1
+
+    def test_document_is_json_compatible(self):
+        doc = build_history().to_dict()
+        # must not raise
+        assert_json_compatible(doc)
+
+    def test_full_roundtrip_preserves_uuids(self):
+        history = build_history()
+        doc = assert_json_compatible(history.to_dict())
+        restored = ChatHistory.from_dict(doc)
+
+        assert [r.uuid for r in restored.raw_records] == [r.uuid for r in history.raw_records]
+        assert [s.uuid for s in restored.summaries] == [s.uuid for s in history.summaries]
+
+    def test_roundtrip_preserves_summary_sets(self):
+        history = build_history()
+        original = history.summaries[0].summarized_messages
+        restored = ChatHistory.from_dict(assert_json_compatible(history.to_dict()))
+        assert isinstance(restored.summaries[0].summarized_messages, set)
+        assert restored.summaries[0].summarized_messages == original
+
+    def test_roundtrip_preserves_record_payloads(self):
+        history = build_history()
+        restored = ChatHistory.from_dict(assert_json_compatible(history.to_dict()))
+
+        assert restored.raw_records[0].message.content == "hello"
+        assert restored.raw_records[0].token_count == 5
+        assert restored.raw_records[0].metadata == {"source": "user", "nested": {"k": [1, 2, 3]}}
+        assert restored.raw_records[1].message.tool_calls[0]["id"] == "tc1"
+        assert restored.raw_records[2].message.tool_call_id == "tc1"
+
+    def test_roundtrip_preserves_metadata(self):
+        history = build_history()
+        restored = ChatHistory.from_dict(assert_json_compatible(history.to_dict()))
+        assert restored.current_loop_id == 7
+        assert restored.tool_token_estimate == 42
+
+    def test_record_types_preserved(self):
+        history = build_history()
+        restored = ChatHistory.from_dict(history.to_dict())
+        assert all(isinstance(r, MessageRecord) for r in restored.raw_records)
+        assert all(isinstance(s, SummaryRecord) for s in restored.summaries)
+
+    def test_empty_history_roundtrips(self):
+        restored = ChatHistory.from_dict(assert_json_compatible(ChatHistory().to_dict()))
+        assert restored.raw_records == []
+        assert restored.summaries == []
+
+    def test_model_is_not_required_and_not_serialized(self):
+        doc = build_history().to_dict()
+        # No model was attached -> model metadata is None and absent from reconstruction.
+        assert doc["metadata"]["model"] is None
+        restored = ChatHistory.from_dict(doc)
+        assert restored.model is None
+
+
+# ---------------------------------------------------------------------------
+# Schema drift / robustness
+# ---------------------------------------------------------------------------
+
+class TestSchemaDrift:
+    def test_incompatible_envelope_version_warns_but_loads(self):
+        doc = build_history().to_dict()
+        doc["format"] = {"schema": CHAT_HISTORY_SCHEMA.name, "version": 999}
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            restored = ChatHistory.from_dict(doc)
+        assert any("not compatible" in str(w.message) for w in caught)
+        # still loads best-effort
+        assert len(restored.raw_records) == 3
+
+    def test_missing_schema_marker_warns_but_loads(self):
+        record = MessageRecord(message=HumanMessage(content="hi"))
+        d = record.to_dict()
+        del d["format"]
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            back = MessageRecord.from_dict(d)
+        assert any("missing" in str(w.message) for w in caught)
+        assert back.uuid == record.uuid
+
+    def test_message_format_drift_is_independent_of_envelope(self):
+        # Bumping only the inner message_format must not require touching the
+        # envelope schema: a record with a mismatched message_format still warns
+        # on the inner marker only.
+        record = MessageRecord(message=HumanMessage(content="hi"))
+        d = record.to_dict()
+        d["message_format"] = {"schema": MESSAGE_FORMAT.name, "version": 999}
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            back = MessageRecord.from_dict(d)
+        messages = [str(w.message) for w in caught]
+        # the envelope was untouched, so the only complaint is about the body format
+        assert any(MESSAGE_FORMAT.name in m and "not compatible" in m for m in messages)
+        assert back.message.content == "hi"

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -54,6 +54,10 @@ def build_history() -> ChatHistory:
     )
     history.summaries.append(summary)
 
+    history.set_system_message("you are a helpful assistant")
+    history.set_system_preamble_text("system preamble text")
+    history.set_user_preamble_text("user preamble text")
+
     history.tool_token_estimate = 42
     return history
 
@@ -233,7 +237,15 @@ class TestChatHistorySerde:
     def test_document_shape(self):
         doc = build_history().to_dict()
         assert doc["format"] == CHAT_HISTORY_SCHEMA.to_dict()
-        assert set(doc) == {"format", "metadata", "raw_records", "summaries"}
+        assert set(doc) == {
+            "format",
+            "metadata",
+            "system_message",
+            "system_preamble",
+            "user_preamble",
+            "raw_records",
+            "summaries",
+        }
         assert len(doc["raw_records"]) == 3
         assert len(doc["summaries"]) == 1
 
@@ -290,6 +302,83 @@ class TestChatHistorySerde:
         assert doc["metadata"]["model"] is None
         restored = ChatHistory.from_dict(doc)
         assert restored.model is None
+
+
+class TestSystemMessageAndPreambles:
+    def test_roundtrip_preserves_system_message_and_preambles(self):
+        history = build_history()
+        restored = ChatHistory.from_dict(assert_json_compatible(history.to_dict()))
+
+        assert restored.system_message is not None
+        assert restored.system_message.message.content == "you are a helpful assistant"
+        assert restored.system_message.uuid == history.system_message.uuid
+
+        assert restored.system_preamble is not None
+        assert isinstance(restored.system_preamble.message, SystemMessage)
+        assert restored.system_preamble.message.content == "system preamble text"
+        assert restored.system_preamble.uuid == history.system_preamble.uuid
+        assert restored.system_preamble.metadata == {"preamble": True}
+
+        assert restored.user_preamble is not None
+        assert isinstance(restored.user_preamble.message, HumanMessage)
+        assert restored.user_preamble.message.content == "user preamble text"
+        assert restored.user_preamble.uuid == history.user_preamble.uuid
+
+    def test_unset_fields_serialize_to_null(self):
+        doc = ChatHistory().to_dict()
+        assert doc["system_message"] is None
+        assert doc["system_preamble"] is None
+        assert doc["user_preamble"] is None
+
+    def test_null_fields_roundtrip_to_none(self):
+        restored = ChatHistory.from_dict(assert_json_compatible(ChatHistory().to_dict()))
+        assert restored.system_message is None
+        assert restored.system_preamble is None
+        assert restored.user_preamble is None
+
+    def test_missing_keys_tolerated(self):
+        # A document predating these fields (keys entirely absent) must still load.
+        doc = build_history().to_dict()
+        del doc["system_message"]
+        del doc["system_preamble"]
+        del doc["user_preamble"]
+        restored = ChatHistory.from_dict(doc)
+        assert restored.system_message is None
+        assert restored.system_preamble is None
+        assert restored.user_preamble is None
+        # the rest of the document is unaffected
+        assert len(restored.raw_records) == 3
+
+    def test_setters_target_distinct_fields(self):
+        # Regression: set_system_preamble_text once routed to user_preamble.
+        # The two setters must populate distinct fields and not clobber each other.
+        history = ChatHistory()
+        history.set_system_preamble_text("sys")
+        history.set_user_preamble_text("usr")
+
+        assert history.system_preamble is not None
+        assert isinstance(history.system_preamble.message, SystemMessage)
+        assert history.system_preamble.message.content == "sys"
+
+        assert history.user_preamble is not None
+        assert isinstance(history.user_preamble.message, HumanMessage)
+        assert history.user_preamble.message.content == "usr"
+
+        # And the distinction survives a serde round-trip.
+        restored = ChatHistory.from_dict(assert_json_compatible(history.to_dict()))
+        assert restored.system_preamble.message.content == "sys"
+        assert isinstance(restored.system_preamble.message, SystemMessage)
+        assert restored.user_preamble.message.content == "usr"
+        assert isinstance(restored.user_preamble.message, HumanMessage)
+
+    def test_partial_set_roundtrips(self):
+        history = ChatHistory()
+        history.set_system_message("only a system message")
+        restored = ChatHistory.from_dict(assert_json_compatible(history.to_dict()))
+        assert restored.system_message is not None
+        assert restored.system_message.message.content == "only a system message"
+        assert restored.system_preamble is None
+        assert restored.user_preamble is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds JSON-compatible to_dict()/from_dict() serialization to the chat-history record types and to ChatHistory as an aggregate document, per #81.

The format is reified via a small SerdeSchema value type (frozen, hashable) that can be inspected, compared (is_compatible), and embedded in the output.


Two version concerns are kept independent:

- Envelope schemas (MESSAGE_RECORD_SCHEMA, SUMMARY_RECORD_SCHEMA, CHAT_HISTORY_SCHEMA) — version the record/document structure.
- Message-body format (MESSAGE_FORMAT) — versions how a LangChain BaseMessage is turned into JSON, stamped onto every record as a message_format marker.
If LangChain's wire format drifts, only MESSAGE_FORMAT moves; the envelope versions stay put.

What's included

- MessageRecord.to_dict()/from_dict() — serializes uuid, token_count, metadata (deep-copied), react_loop_id, and the message body via LangChain's
message_to_dict/messages_from_dict. Base-class from_dict dispatches to SummaryRecord when the payload declares the summary schema.
- SummaryRecord — overrides to carry summarized_messages as a sorted list across the JSON boundary, restored to a set on load.
- ChatHistory.to_dict()/from_dict() — aggregate document with format, metadata (model descriptor, loop id, thresholds, token estimates), system_message,
system_preamble, user_preamble, raw_records, and summaries. The model and runtime-only state (summarizers, in-flight task) are intentionally not
serialized; pass a live model/summarizers to from_dict.
- Lenient schema checking — missing or incompatible markers warn (with the expected vs. found schema) rather than raise, so older/newer documents load best-effort. Absent optional keys (system message/preambles) are tolerated for forward/backward compatibility.
- Fixes pre-existing bug in set_system_preamble_test method

Guarantees verified by tests

- ChatHistory → dict → ChatHistory preserves all record uuids unchanged.
- SummaryRecords reconstruct with their summarized_messages sets intact.
- Each record carries an inner message_format marker, independent of the envelope version.
- System message and preambles round-trip (including body message type and metadata), and serialize to null / reconstruct to None when unset or absent.

Tests

- New tests/test_serde.py — 38 pure unit tests (no API keys/model required) covering SerdeSchema semantics, record/summary round-trips, the aggregate document, system-message/preamble handling, and schema-drift robustness.
- Test covering set_system_preamble_test behavior